### PR TITLE
accelerate get table speed

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaData.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaData.java
@@ -685,28 +685,26 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
     long begin = System.currentTimeMillis();
 
     List<Object[]> rows = new ArrayList<Object[]>();
+
     for (Table t : conn.getOdps().tables()) {
 
-      Object[] rowVals = {null, t.getProject(), t.getName(),
-                          t.isVirtualView() ? "VIEW" : "TABLE", t.getComment(), null, null, null,
-                          null, "USER"};
-
+      String tableName = t.getName();
       if (tableNamePattern != null) {
-        if (!Utils.matchPattern(t.getName(), tableNamePattern)) {
+        if (!Utils.matchPattern(tableName, tableNamePattern)) {
           continue;
         }
       }
 
+      String tableType = t.isVirtualView() ? "VIEW" : "TABLE";
       if (types != null && types.length != 0) {
-        for (String type : types) {
-          if (type.equals(t.isVirtualView() ? "VIEW" : "TABLE")) {
-            rows.add(rowVals);
-            break;
-          }
+        if (!Arrays.asList(types).contains(tableType)) {
+          continue;
         }
-      } else {
-        rows.add(rowVals);
       }
+
+      Object[] rowVals = {null, t.getProject(), tableName, tableType, t.getComment(),
+                          null, null, null, null, "USER"};
+      rows.add(rowVals);
     }
 
     long end = System.currentTimeMillis();
@@ -781,9 +779,8 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
       for (int i = 0; i < columns.size(); i++) {
         Column col = columns.get(i);
         JdbcColumn jdbcCol = new JdbcColumn(col.getName(), tableNamePattern,
-                                            conn.getOdps().getEndpoint(), col.getType(),
+                                            null, col.getType(),
                                             col.getComment(), i + 1);
-
         Object[] rowVals = {
             jdbcCol.getTableCatalog(), null, jdbcCol.getTableName(), jdbcCol.getColumnName(),
             (long) jdbcCol.getType(), jdbcCol.getTypeName(), null, null,

--- a/src/test/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaDataTest.java
+++ b/src/test/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaDataTest.java
@@ -88,7 +88,8 @@ public class OdpsDatabaseMetaDataTest {
       ResultSet rs = databaseMetaData.getTables(null, null, "bad\\_%\\_test", null);
       Assert.assertNotNull(rs);
       while (rs.next()) {
-        Assert.assertTrue(rs.getString("TABLE_NAME").equals("bad_folder_test"));
+        Assert.assertTrue(rs.getString("TABLE_NAME").startsWith("bad"));
+        Assert.assertTrue(rs.getString("TABLE_NAME").endsWith("test"));
       }
       rs.close();
     }
@@ -98,6 +99,15 @@ public class OdpsDatabaseMetaDataTest {
       Assert.assertNotNull(rs);
       while (rs.next()) {
         Assert.assertTrue(rs.getString("TABLE_NAME").endsWith("test"));
+      }
+      rs.close();
+    }
+
+    {
+      ResultSet rs = databaseMetaData.getTables(null, null, null, new String[] {"TABLE"});
+      Assert.assertNotNull(rs);
+      while (rs.next()) {
+        Assert.assertTrue(rs.getString("TABLE_TYPE").equals("TABLE"));
       }
       rs.close();
     }


### PR DESCRIPTION
The getTables() should not read all the meta info of a table until we can decide a table is finally needed.

When there are a lot of tables in the project, this can save a lot of time. (from about 30s to 2s)

Also refactor the code to be shorter

