### PR TITLE
Fix a NPE bug in StaticResultSet.

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaData.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaData.java
@@ -664,7 +664,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
                       OdpsType.STRING, OdpsType.STRING, OdpsType.STRING, OdpsType.BIGINT,
                       OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -676,7 +676,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList("STUPID_PLACEHOLDERS", "USELESS_PLACEHOLDER"),
         Arrays.asList(OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -718,7 +718,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
                       OdpsType.STRING, OdpsType.STRING, OdpsType.STRING, OdpsType.STRING,
                       OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta, rows.iterator());
+    return new OdpsStaticResultSet(getConnection(), meta, rows.iterator());
   }
 
   // TODO
@@ -729,7 +729,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList("STUPID_PLACEHOLDERS", "USELESS_PLACEHOLDER"),
         Arrays.asList(OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   // TODO
@@ -741,7 +741,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList("STUPID_PLACEHOLDERS", "USELESS_PLACEHOLDER"),
         Arrays.asList(OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -751,7 +751,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList("STUPID_PLACEHOLDERS", "USELESS_PLACEHOLDER"),
         Arrays.asList(OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -761,7 +761,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList("STUPID_PLACEHOLDERS", "USELESS_PLACEHOLDER"),
         Arrays.asList(OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -816,7 +816,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
                           OdpsType.BIGINT, OdpsType.STRING, OdpsType.STRING, OdpsType.STRING,
                           OdpsType.STRING, OdpsType.BIGINT));
 
-    return new OdpsStaticResultSet(meta, rows.iterator());
+    return new OdpsStaticResultSet(getConnection(), meta, rows.iterator());
   }
 
   @Override
@@ -854,7 +854,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList(OdpsType.STRING, OdpsType.STRING, OdpsType.STRING, OdpsType.STRING,
                       OdpsType.BIGINT, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -871,7 +871,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
                       OdpsType.BIGINT, OdpsType.BIGINT, OdpsType.BIGINT, OdpsType.STRING,
                       OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -895,7 +895,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList("STUPID_PLACEHOLDERS", "USELESS_PLACEHOLDER"),
         Arrays.asList(OdpsType.STRING, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -976,7 +976,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList(OdpsType.STRING, OdpsType.STRING, OdpsType.STRING, OdpsType.STRING,
                       OdpsType.BIGINT, OdpsType.STRING, OdpsType.BIGINT));
 
-    return new OdpsStaticResultSet(meta);
+    return new OdpsStaticResultSet(getConnection(), meta);
   }
 
   @Override
@@ -1108,7 +1108,7 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
         Arrays.asList(OdpsType.STRING, OdpsType.STRING, OdpsType.STRING, OdpsType.STRING,
                       OdpsType.BIGINT, OdpsType.STRING));
 
-    return new OdpsStaticResultSet(meta, rows.iterator());
+    return new OdpsStaticResultSet(getConnection(), meta, rows.iterator());
   }
 
   @Override

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsResultSet.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsResultSet.java
@@ -42,21 +42,20 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Map;
-import java.util.logging.Logger;
 
 public abstract class OdpsResultSet extends WrapperAdapter implements ResultSet {
 
-  private final Logger log;
   private OdpsResultSetMetaData meta;
   private OdpsStatement stmt;
+  protected OdpsConnection conn;
   private boolean wasNull = false;
 
   private SQLWarning warningChain = null;
 
-  OdpsResultSet(OdpsStatement stmt, OdpsResultSetMetaData meta) throws SQLException {
+  OdpsResultSet(OdpsConnection conn, OdpsStatement stmt, OdpsResultSetMetaData meta) throws SQLException {
     this.stmt = stmt;
     this.meta = meta;
-    this.log = stmt.getParentLogger();
+    this.conn = conn;
   }
 
   @Override
@@ -571,7 +570,7 @@ public abstract class OdpsResultSet extends WrapperAdapter implements ResultSet 
       } catch (UnsupportedEncodingException e) {
         throw new SQLException(e);
       }
-      log.info("no specified charset found, using system default charset decoder");
+      conn.log.info("no specified charset found, using system default charset decoder");
       // Use the java.nio.charset.CharsetDecoder to decode the byte[]
       return new String((byte[]) obj);
     } else if (obj instanceof java.util.Date) {

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsScollResultSet.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsScollResultSet.java
@@ -32,7 +32,6 @@ import com.aliyun.odps.tunnel.io.TunnelRecordReader;
 
 public class OdpsScollResultSet extends OdpsResultSet implements ResultSet {
 
-  private Logger log;
   private DownloadSession sessionHandle;
   private int fetchSize;
   private OdpsStatement.FetchDirection fetchDirection;
@@ -60,8 +59,7 @@ public class OdpsScollResultSet extends OdpsResultSet implements ResultSet {
 
   OdpsScollResultSet(OdpsStatement stmt, OdpsResultSetMetaData meta, DownloadSession session)
       throws SQLException {
-    super(stmt, meta);
-    log = stmt.getParentLogger();
+    super(stmt.getConnection(), stmt, meta);
     sessionHandle = session;
     fetchSize = stmt.resultSetFetchSize;
     fetchDirection = stmt.resultSetFetchDirection;
@@ -238,7 +236,7 @@ public class OdpsScollResultSet extends OdpsResultSet implements ResultSet {
       default:
         throw new SQLException("invalid argument for setFetchDirection()");
     }
-    log.info("setFetchDirection has not been utilized");
+    conn.log.info("setFetchDirection has not been utilized");
   }
 
   @Override
@@ -310,7 +308,7 @@ public class OdpsScollResultSet extends OdpsResultSet implements ResultSet {
       }
       long duration = System.currentTimeMillis() - start;
       long totalKBytes = reader.getTotalBytes() / 1024;
-      log.fine(String.format("fetch records, start=%d, cnt=%d, %d KB, %.2f KB/s", cachedUpperRow,
+      conn.log.fine(String.format("fetch records, start=%d, cnt=%d, %d KB, %.2f KB/s", cachedUpperRow,
                               count, totalKBytes, (float) totalKBytes / duration * 1000));
       reader.close();
     } catch (TunnelException e) {

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsStaticResultSet.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsStaticResultSet.java
@@ -35,8 +35,8 @@ class OdpsStaticResultSet extends OdpsResultSet implements ResultSet {
    */
   private boolean isEmptyResultSet = false;
 
-  OdpsStaticResultSet(OdpsResultSetMetaData meta) throws SQLException {
-    super(null, meta);
+  OdpsStaticResultSet(OdpsConnection conn, OdpsResultSetMetaData meta) throws SQLException {
+    super(conn, null, meta);
     // Construct an empty result set
     isEmptyResultSet = true;
   }
@@ -44,9 +44,9 @@ class OdpsStaticResultSet extends OdpsResultSet implements ResultSet {
   /**
    * For non-empty result set, its data is passed via parameter
    */
-  OdpsStaticResultSet(OdpsResultSetMetaData meta, Iterator<Object[]> iter)
+  OdpsStaticResultSet(OdpsConnection conn, OdpsResultSetMetaData meta, Iterator<Object[]> iter)
       throws SQLException {
-    super(null, meta);
+    super(conn, null, meta);
     iterator = iter;
     isEmptyResultSet = false;
   }


### PR DESCRIPTION
This bug is introduced when reformatting the per-connection logger. StaticResultSet derives from dataBaseMetaData, but not Statement. So it fail to find the logger in connection. Now we store a conn handle in each ResultSet and its extended class.