### PR TITLE
修改默认字符串类型以支持Pentaho

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v1.3 (SNAPSHOT)
+
+1. Support `supportsResultSetType()` to adapt Pentaho.
+1. Support `PreparedStatement.setBytes()`.
+
 ### v1.2 (2015-11-29)
 
 1. Support batch insert in PreparedStatement.

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ The implicit type conversion follows the rule:
 | float        | Y | Y |   |   | Y | Y |
 | BigDecimal  |   |   |   |   | Y | Y |
 | String       | Y | Y | Y | Y | Y | Y |
+| byte\[\]     | Y | Y | Y | Y | Y | Y |
 | Date         |   |   |   | Y | Y |   |
 | Time         |   |   |   | Y | Y |   |
 | Timestamp   |   |   |   | Y | Y |   |

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaData.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsDatabaseMetaData.java
@@ -905,7 +905,11 @@ public class OdpsDatabaseMetaData extends WrapperAdapter implements DatabaseMeta
 
   @Override
   public boolean supportsResultSetType(int type) throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    if (type == ResultSet.TYPE_FORWARD_ONLY || type == ResultSet.TYPE_SCROLL_INSENSITIVE) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   @Override

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsPreparedStatement.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsPreparedStatement.java
@@ -27,7 +27,6 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
-import java.sql.BatchUpdateException;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
@@ -53,9 +52,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.aliyun.odps.OdpsType;
 import com.aliyun.odps.TableSchema;
-import com.aliyun.odps.data.ArrayRecord;
 import com.aliyun.odps.data.Record;
 import com.aliyun.odps.tunnel.TableTunnel;
 import com.aliyun.odps.tunnel.TunnelException;
@@ -315,7 +312,7 @@ public class OdpsPreparedStatement extends OdpsStatement implements PreparedStat
 
   @Override
   public void setBytes(int parameterIndex, byte[] x) throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    parameters.put(parameterIndex, x);
   }
 
   @Override
@@ -413,7 +410,7 @@ public class OdpsPreparedStatement extends OdpsStatement implements PreparedStat
     } else if (x instanceof String) {
       setString(parameterIndex, (String) x);
     } else if (x instanceof byte[]) {
-      parameters.put(parameterIndex, x);
+      setBytes(parameterIndex, (byte[]) x);
     } else if (x instanceof Short) {
       setShort(parameterIndex, (Short) x);
     } else if (x instanceof Integer) {


### PR DESCRIPTION
为适配 Pentaho 报表软件

* 实现了 `supportsResultSetType()`
* 改了默认的字符串类型，否则会显示成byte[]这样的乱码。

原来的内部表示是 byte[] 是因为从 tunnel 中 get 到的 object 就是 byte[]，但 Pentaho 不会专门地根据类型去调 getString，所以内部 JDBC 对外暴露的字符串默认类型必须为 String 不能是 byte[]，所以在 getObject 之后做了一个额外的判断，其他类型则没有这个问题。

回头可以加写一个连接 pentaho 的教程。