### PR TITLE
feature: add use project timezone option

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/OdpsConnection.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsConnection.java
@@ -63,6 +63,7 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
   private static final AtomicLong CONNECTION_ID_GENERATOR = new AtomicLong(0);
 
   private final Odps odps;
+  private final TimeZone tz;
   private final Properties info;
   private final List<Statement> stmtHandles;
 
@@ -105,6 +106,8 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
   private Long resultSizeLimit = null;
 
   private boolean disableConnSetting = false;
+
+  private boolean useProjectTimeZone = false;
 
   private SQLExecutor executor = null;
 
@@ -168,7 +171,7 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
     this.logviewHost = logviewHost;
     this.lifecycle = lifecycle;
     this.tunnelEndpoint = tunnelEndpoint;
-    this.stmtHandles = new ArrayList<Statement>();
+    this.stmtHandles = new ArrayList<>();
 
     this.majorVersion = connRes.getMajorVersion();
     this.interactiveMode = connRes.isInteractiveMode();
@@ -177,9 +180,20 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
     this.resultCountLimit = connRes.getCountLimit();
     this.resultSizeLimit = connRes.getSizeLimit();
     this.disableConnSetting = connRes.isDisableConnSetting();
+    this.useProjectTimeZone = connRes.isUseProjectTimeZone();
+
     try {
       long startTime = System.currentTimeMillis();
-      odps.projects().get().reload();
+
+      // Default value for odps.sql.timezone
+      String timeZoneId = "Asia/Shanghai";
+      String projectTimeZoneId = odps.projects().get().getProperty("odps.sql.timezone");
+      if (!StringUtils.isNullOrEmpty(projectTimeZoneId)) {
+        timeZoneId = projectTimeZoneId;
+      }
+
+      log.info("Project timezone: " + timeZoneId);
+      tz = TimeZone.getTimeZone(timeZoneId);
       if (interactiveMode) {
         long cost = System.currentTimeMillis() - startTime;
         log.info(String.format("load project meta infos time cost=%d", cost));
@@ -583,26 +597,31 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
     throw new SQLFeatureNotSupportedException();
   }
 
+  @Override
   public void setSchema(String schema) throws SQLException {
     checkClosed();
     odps.setDefaultProject(schema);
   }
 
+  @Override
   public String getSchema() throws SQLException {
     checkClosed();
     return odps.getDefaultProject();
   }
 
+  @Override
   public void abort(Executor executor) throws SQLException {
     log.error(Thread.currentThread().getStackTrace()[1].getMethodName() + " is not supported!!!");
     throw new SQLFeatureNotSupportedException();
   }
 
+  @Override
   public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
     log.error(Thread.currentThread().getStackTrace()[1].getMethodName() + " is not supported!!!");
     throw new SQLFeatureNotSupportedException();
   }
 
+  @Override
   public int getNetworkTimeout() throws SQLException {
     log.error(Thread.currentThread().getStackTrace()[1].getMethodName() + " is not supported!!!");
     throw new SQLFeatureNotSupportedException();
@@ -610,6 +629,22 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
 
   public Odps getOdps() {
     return this.odps;
+  }
+
+  public TimeZone getProjectTimeZone() {
+    return tz;
+  }
+
+  public boolean isUseProjectTimeZone() {
+    return useProjectTimeZone;
+  }
+
+  /**
+   * For test
+   * @param useProjectTimeZone
+   */
+  public void setUseProjectTimeZone(boolean useProjectTimeZone) {
+    this.useProjectTimeZone = useProjectTimeZone;
   }
 
   private void checkClosed() throws SQLException {

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsResultSet.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsResultSet.java
@@ -40,6 +40,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
+import java.util.TimeZone;
 
 import com.aliyun.odps.jdbc.utils.transformer.to.jdbc.AbstractToJdbcDateTypeTransformer;
 import com.aliyun.odps.jdbc.utils.transformer.to.jdbc.AbstractToJdbcTransformer;
@@ -653,8 +654,10 @@ public abstract class OdpsResultSet extends WrapperAdapter implements ResultSet 
 
   private Object transformToJdbcType(Object o, Class jdbcCls, Calendar cal) throws SQLException {
     AbstractToJdbcTransformer transformer = ToJdbcTransformerFactory.getTransformer(jdbcCls);
+
+    TimeZone projectTimeZone = conn.isUseProjectTimeZone() ? conn.getProjectTimeZone() : null;
     return ((AbstractToJdbcDateTypeTransformer) transformer).transform(
-        o, stmt.getConnection().getCharset(), cal);
+        o, stmt.getConnection().getCharset(), cal, projectTimeZone);
   }
 
   @Override

--- a/src/main/java/com/aliyun/odps/jdbc/utils/ConnectionResource.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/ConnectionResource.java
@@ -69,6 +69,7 @@ public class ConnectionResource {
   private static final String INSTANCE_TUNNEL_MAX_SIZE_URL_KEY = "instanceTunnelMaxSize";
   private static final String STS_TOKEN_URL_KEY = "stsToken";
   private static final String DISABLE_CONN_SETTING_URL_KEY = "disableConnectionSetting";
+  private static final String USE_PROJECT_TIME_ZONE_URL_KEY = "useProjectTimeZone";
 
   /**
    * Keys to retrieve properties from info.
@@ -102,6 +103,7 @@ public class ConnectionResource {
   private static final String INSTANCE_TUNNEL_MAX_SIZE_PROP_KEY = "instance_tunnel_max_size";
   private static final String STS_TOKEN_PROP_KEY = "sts_token";
   private static final String DISABLE_CONN_SETTING_PROP_KEY = "disable_connection_setting";
+  private static final String USE_PROJECT_TIME_ZONE_PROP_KEY = "use_project_time_zone";
 
   // This is to support DriverManager.getConnection(url, user, password) API,
   // which put the 'user' and 'password' to the 'info'.
@@ -130,6 +132,7 @@ public class ConnectionResource {
   private Long sizeLimit;
   private String stsToken;
   private boolean disableConnSetting = false;
+  private boolean useProjectTimeZone = false;
 
   public static boolean acceptURL(String url) {
     return (url != null) && url.startsWith(JDBC_ODPS_URL_PREFIX);
@@ -249,6 +252,10 @@ public class ConnectionResource {
 
     disableConnSetting = Boolean.valueOf(
         tryGetFirstNonNullValueByAltMapAndAltKey(maps, "false", DISABLE_CONN_SETTING_PROP_KEY, DISABLE_CONN_SETTING_URL_KEY)
+    );
+
+    useProjectTimeZone = Boolean.valueOf(
+        tryGetFirstNonNullValueByAltMapAndAltKey(maps, "false", USE_PROJECT_TIME_ZONE_PROP_KEY, USE_PROJECT_TIME_ZONE_URL_KEY)
     );
 
     String tableStr = tryGetFirstNonNullValueByAltMapAndAltKey(maps, null, TABLE_LIST_PROP_KEY,
@@ -378,5 +385,9 @@ public class ConnectionResource {
 
   public boolean isDisableConnSetting() {
     return disableConnSetting;
+  }
+
+  public boolean isUseProjectTimeZone() {
+    return useProjectTimeZone;
   }
 }

--- a/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/AbstractToJdbcDateTypeTransformer.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/AbstractToJdbcDateTypeTransformer.java
@@ -4,6 +4,7 @@ import com.aliyun.odps.jdbc.utils.JdbcColumn;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 public abstract class AbstractToJdbcDateTypeTransformer extends AbstractToJdbcTransformer {
   static ThreadLocal<SimpleDateFormat> DATETIME_FORMAT = new ThreadLocal<>();
@@ -17,7 +18,7 @@ public abstract class AbstractToJdbcDateTypeTransformer extends AbstractToJdbcTr
 
   @Override
   public Object transform(Object o, String charset) throws SQLException {
-    return this.transform(o, charset, null);
+    return this.transform(o, charset, null, null);
   }
 
   /**
@@ -28,7 +29,11 @@ public abstract class AbstractToJdbcDateTypeTransformer extends AbstractToJdbcTr
    * @return JDBC object
    * @throws SQLException
    */
-  public abstract Object transform(Object o, String charset, Calendar cal) throws SQLException;
+  public abstract Object transform(
+      Object o,
+      String charset,
+      Calendar cal,
+      TimeZone projectTimeZone) throws SQLException;
 
   void restoreToDefaultCalendar() {
     DATETIME_FORMAT.get().setCalendar(Calendar.getInstance());

--- a/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcDateTransformer.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcDateTransformer.java
@@ -24,18 +24,28 @@ import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 
-public class ToJdbcDateToJdbcDateTypeTransformer extends AbstractToJdbcDateTypeTransformer {
+public class ToJdbcDateTransformer extends AbstractToJdbcDateTypeTransformer {
 
   @Override
-  public Object transform(Object o, String charset, Calendar cal) throws SQLException {
+  public Object transform(
+      Object o,
+      String charset,
+      Calendar cal,
+      TimeZone projectTimeZone) throws SQLException {
+
     if (o == null) {
       return null;
     }
 
     if (java.util.Date.class.isInstance(o)) {
-      return new java.sql.Date(((java.util.Date) o).getTime());
+      long time = ((java.util.Date) o).getTime();
+      if (projectTimeZone != null) {
+        time += projectTimeZone.getOffset(time);
+      }
+      return new java.sql.Date(time);
     } else if (o instanceof byte[]) {
       try {
         SimpleDateFormat datetimeFormat = DATETIME_FORMAT.get();

--- a/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcTimeTransfomer.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcTimeTransfomer.java
@@ -24,18 +24,28 @@ import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 
 public class ToJdbcTimeTransfomer extends AbstractToJdbcDateTypeTransformer {
 
   @Override
-  public Object transform(Object o, String charset, Calendar cal) throws SQLException {
+  public Object transform(
+      Object o,
+      String charset,
+      Calendar cal,
+      TimeZone projectTimeZone) throws SQLException {
+
     if (o == null) {
       return null;
     }
 
     if (java.util.Date.class.isInstance(o)) {
-      return new java.sql.Time(((java.util.Date) o).getTime());
+      long time = ((java.util.Date) o).getTime();
+      if (projectTimeZone != null) {
+        time += projectTimeZone.getOffset(time);
+      }
+      return new java.sql.Time(time);
     } else if (o instanceof byte[]) {
       try {
         SimpleDateFormat datetimeFormat = DATETIME_FORMAT.get();

--- a/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcTransformerFactory.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcTransformerFactory.java
@@ -40,7 +40,7 @@ public class ToJdbcTransformerFactory {
   private static final ToJdbcBigDecimalTransformer BIG_DECIMAL_TRANSFORMER = new ToJdbcBigDecimalTransformer();
   private static final ToJdbcStringTransformer STRING_TRANSFORMER = new ToJdbcStringTransformer();
   private static final ToJdbcByteArrayTransformer BYTE_ARRAY_TRANSFORMER = new ToJdbcByteArrayTransformer();
-  private static final ToJdbcDateToJdbcDateTypeTransformer DATE_TRANSFORMER = new ToJdbcDateToJdbcDateTypeTransformer();
+  private static final ToJdbcDateTransformer DATE_TRANSFORMER = new ToJdbcDateTransformer();
   private static final ToJdbcTimeTransfomer TIME_TRANSFORMER = new ToJdbcTimeTransfomer();
   private static final ToJdbcTimestampTransformer TIMESTAMP_TRANSFORMER = new ToJdbcTimestampTransformer();
   private static final ToJdbcBooleanTransformer BOOLEAN_TRANSFORMER = new ToJdbcBooleanTransformer();


### PR DESCRIPTION
## What do these changes do?

Add an option 'useProjectTimeZone'. ResultSet.getTime, ResultSet.getDate and ResultSet.getTimestamp will construct the Object using the project's time zone. 

## Related issue number

