### PR TITLE
fix: handle the incompatible change of SDK

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/AbstractToJdbcDateTypeTransformer.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/AbstractToJdbcDateTypeTransformer.java
@@ -7,6 +7,7 @@ import java.util.Calendar;
 import java.util.TimeZone;
 
 public abstract class AbstractToJdbcDateTypeTransformer extends AbstractToJdbcTransformer {
+  static ThreadLocal<Calendar> DEFAULT_CALENDAR = ThreadLocal.withInitial(() -> new Calendar.Builder().setCalendarType("iso8601").setTimeZone(TimeZone.getTimeZone("GMT")).build());
   static ThreadLocal<SimpleDateFormat> TIMESTAMP_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat(JdbcColumn.ODPS_TIMESTAMP_FORMAT));
   static ThreadLocal<SimpleDateFormat> DATETIME_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat(JdbcColumn.ODPS_DATETIME_FORMAT));
   static ThreadLocal<SimpleDateFormat> DATE_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat(JdbcColumn.ODPS_DATE_FORMAT));

--- a/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcDateTransformer.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/transformer/to/jdbc/ToJdbcDateTransformer.java
@@ -23,6 +23,7 @@ package com.aliyun.odps.jdbc.utils.transformer.to.jdbc;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -46,6 +47,16 @@ public class ToJdbcDateTransformer extends AbstractToJdbcDateTypeTransformer {
         time += timeZone.getOffset(time);
       }
       return new java.sql.Date(time);
+    } else if (o instanceof LocalDate) {
+      LocalDate localDate = (LocalDate) o;
+      Calendar calendar = (Calendar) DEFAULT_CALENDAR.get().clone();
+      calendar.clear();
+      calendar.set(
+          localDate.getYear(),
+          // Starts from 0
+          localDate.getMonth().getValue() - 1,
+          localDate.getDayOfMonth());
+      return new java.sql.Date(calendar.getTime().getTime());
     } else if (o instanceof byte[]) {
       try {
         SimpleDateFormat datetimeFormat = DATETIME_FORMAT.get();


### PR DESCRIPTION
1. handle the change of internal representation of SQL DATE from java.sql.Date to java.time.LocalDate

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
