### PR TITLE
修复Varchar类型和Char类型参数在执行查询时，未转换为字符串导致查询SQL异常的问题

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/OdpsPreparedStatement.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsPreparedStatement.java
@@ -584,9 +584,9 @@ public class OdpsPreparedStatement extends OdpsStatement implements PreparedStat
     } else if (x instanceof Instant) {
       parameters.put(parameterIndex, x);
     } else if (x instanceof Varchar) {
-      parameters.put(parameterIndex, x);
+      setString(parameterIndex, x.toString());
     } else if (x instanceof Char) {
-      parameters.put(parameterIndex, x);
+      setString(parameterIndex, x.toString());
     } else if (x instanceof Binary) {
       parameters.put(parameterIndex, x);
     } else {
@@ -771,8 +771,6 @@ public class OdpsPreparedStatement extends OdpsStatement implements PreparedStat
       return String.format("%s", x.toString());
     } else if (BigDecimal.class.isInstance(x)) {
       return String.format("%sBD", x.toString());
-    } else if (Varchar.class.isInstance(x)) {
-      return x.toString();
     } else if (String.class.isInstance(x)) {
       if (isIllegal((String) x)) {
         throw new IllegalArgumentException("");
@@ -826,9 +824,15 @@ public class OdpsPreparedStatement extends OdpsStatement implements PreparedStat
     } else if (Binary.class.isInstance(x)) {
       return String.format("unhex('%s')", x);
     } else if (Varchar.class.isInstance(x)) {
-      return x.toString();
+      if (isIllegal(x.toString())) {
+        throw new IllegalArgumentException("");
+      }
+      return "'" + x.toString() + "'";
     } else if (Char.class.isInstance(x)) {
-      return x.toString();
+      if (isIllegal(x.toString())) {
+        throw new IllegalArgumentException("");
+      }
+      return "'" + x.toString() + "'";
     } else {
       throw new SQLException("unrecognized Java class: " + x.getClass().getName());
     }


### PR DESCRIPTION
## What do these changes do?

修复当查询结果类型为Varchar和Char时，将查询结果直接作为下一个查询的参数，执行executeQuery时，SQL无法将Varchar和Char识别为字符串类型的问题
以下为一个简单复现问题的示例：
```sql
create table tab_1(
     col_1 varchar(32),
     col_2 varchar(32)
);

create table tab_2(
     col_1 varchar(32),
     col_3 varchar(32)
);
```
使用一下代码进行查询时，会出现注释中的情况
```java
PreparedStatement ps1 = conn.prepareStatement("select distinct col_1 from tab_1");
ResultSet rs = ps1.executeQuery();
PreparedStatement ps2 = conn.prepareStatement("select * from tab_2 where col_1 = ?");
while(rs.next()){
    ps2.setObject(rs.getObject(1));  // rs.getObject 返回为Varchar类型，假设返回的结果为test字符串
    ps2.executeQuery();  // 此处实际执行的SQL为select * from tab_2 where col_1 = test，而非select * from tab_2 where col_1 = 'test'
}
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
