### PR TITLE
feat: implement SettingParser for accurate SQL settings extraction

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/OdpsStatement.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsStatement.java
@@ -39,6 +39,7 @@ import com.aliyun.odps.Instance;
 import com.aliyun.odps.OdpsException;
 import com.aliyun.odps.data.Record;
 import com.aliyun.odps.jdbc.utils.OdpsLogger;
+import com.aliyun.odps.jdbc.utils.SettingParser;
 import com.aliyun.odps.jdbc.utils.Utils;
 import com.aliyun.odps.sqa.ExecuteMode;
 import com.aliyun.odps.sqa.SQLExecutor;
@@ -204,10 +205,11 @@ public class OdpsStatement extends WrapperAdapter implements Statement {
     Properties properties = new Properties();
 
     if (!connHandle.isSkipSqlCheck()) {
-      query = Utils.parseSetting(query, properties);
+      SettingParser.ParseResult parseResult = SettingParser.parse(query);
+      query = parseResult.getRemainingQuery();
+      properties.putAll(parseResult.getSettings());
     }
-
-    if (StringUtils.isNullOrEmpty(query)) {
+    if (StringUtils.isBlank(query)) {
       // only settings, just set properties
       processSetClause(properties);
       return EMPTY_RESULT_SET;
@@ -235,10 +237,12 @@ public class OdpsStatement extends WrapperAdapter implements Statement {
 
     Properties properties = new Properties();
     if (!connHandle.isSkipSqlCheck()) {
-      query = Utils.parseSetting(query, properties);
+      SettingParser.ParseResult parseResult = SettingParser.parse(query);
+      query = parseResult.getRemainingQuery();
+      properties.putAll(parseResult.getSettings());
     }
 
-    if (StringUtils.isNullOrEmpty(query)) {
+    if (StringUtils.isBlank(query)) {
       // only settings, just set properties
       processSetClause(properties);
       return 0;
@@ -290,7 +294,9 @@ public class OdpsStatement extends WrapperAdapter implements Statement {
     Properties properties = new Properties();
 
     if (!connHandle.isSkipSqlCheck()) {
-      query = Utils.parseSetting(query, properties);
+      SettingParser.ParseResult parseResult = SettingParser.parse(query);
+      query = parseResult.getRemainingQuery();
+      properties.putAll(parseResult.getSettings());
     }
 
     if (StringUtils.isNullOrEmpty(query)) {

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsStatement.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsStatement.java
@@ -299,7 +299,7 @@ public class OdpsStatement extends WrapperAdapter implements Statement {
       properties.putAll(parseResult.getSettings());
     }
 
-    if (StringUtils.isNullOrEmpty(query)) {
+    if (StringUtils.isBlank(query)) {
       // only settings, just set properties
       processSetClause(properties);
       return false;

--- a/src/main/java/com/aliyun/odps/jdbc/utils/SettingParser.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/SettingParser.java
@@ -1,0 +1,171 @@
+package com.aliyun.odps.jdbc.utils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SettingParser {
+  public static ParseResult parse(String query) {
+    SettingParser parser = new SettingParser();
+    return parser.extractSetStatements(query);
+  }
+
+  enum State {
+    DEFAULT,
+    SINGLE_LINE_COMMENT,
+    MULTI_LINE_COMMENT,
+    IN_SET,
+    IN_KEY_VALUE,
+    STOP
+  }
+
+  public static class ParseResult {
+
+    private final Map<String, String> settings;
+    private final String remainingQuery;
+    private final List<String> errors;
+
+    public ParseResult(Map<String, String> settings, String remainingQuery, List<String> errors) {
+      this.settings = settings;
+      this.remainingQuery = remainingQuery;
+      this.errors = errors;
+    }
+
+    public Map<String, String> getSettings() {
+      return settings;
+    }
+
+    public String getRemainingQuery() {
+      return remainingQuery;
+    }
+
+    public List<String> getErrors() {
+      return errors;
+    }
+  }
+
+  public ParseResult extractSetStatements(String s) {
+    Map<String, String> settings = new LinkedHashMap<>();
+    List<String> errors = new ArrayList<>();
+    List<int[]> excludeRanges = new ArrayList<>();
+    State currentState = State.DEFAULT;
+    int i = 0;
+    int currentStartIndex = -1;
+
+    while (i < s.length()) {
+      switch (currentState) {
+        case DEFAULT:
+          if (i <= s.length() - 2 && s.startsWith("--", i)) {
+            currentState = State.SINGLE_LINE_COMMENT;
+            i += 2;
+          } else if (i <= s.length() - 2 && s.startsWith("/*", i)) {
+            currentState = State.MULTI_LINE_COMMENT;
+            i += 2;
+          } else if (i <= s.length() - 3 && (s.startsWith("set", i) || s.startsWith("SET", i))) {
+            if (i + 3 < s.length() && Character.isWhitespace(s.charAt(i + 3))) {
+              currentState = State.IN_SET;
+              currentStartIndex = i;
+              i += 4; // Skip 'set' and the following whitespace
+            } else {
+              i++;
+            }
+          } else {
+            if (!Character.isWhitespace(s.charAt(i))) {
+              currentState = State.STOP;
+            }
+            i++;
+          }
+          break;
+        case SINGLE_LINE_COMMENT:
+          while (i < s.length() && s.charAt(i) != '\n') {
+            i++;
+          }
+          if (i < s.length()) {
+            i++;
+          }
+          currentState = State.DEFAULT;
+          break;
+        case MULTI_LINE_COMMENT:
+          while (i < s.length()) {
+            if (i + 1 < s.length() && s.startsWith("*/", i)) {
+              i += 2;
+              currentState = State.DEFAULT;
+              break;
+            } else {
+              i++;
+            }
+          }
+          break;
+        case IN_SET:
+          while (i < s.length() && Character.isWhitespace(s.charAt(i))) {
+            i++;
+          }
+          if (i < s.length()) {
+            currentState = State.IN_KEY_VALUE;
+          } else {
+            errors.add("Invalid SET statement: missing key-value after 'set'");
+            currentStartIndex = -1;
+            currentState = State.DEFAULT;
+          }
+          break;
+        case IN_KEY_VALUE:
+          int keyValueStart = i;
+          boolean foundSemicolon = false;
+          while (i < s.length()) {
+            if (s.charAt(i) == ';' && s.charAt(i - 1) != '\\') {
+              foundSemicolon = true;
+              i++;
+              break;
+            }
+            i++;
+          }
+          if (foundSemicolon) {
+            excludeRanges.add(new int[]{currentStartIndex, i});
+            String kv = s.substring(keyValueStart, i - 1).trim();
+            parseKeyValue(kv, settings, errors);
+          } else {
+            errors.add("Invalid SET statement: missing semicolon");
+          }
+          currentState = State.DEFAULT;
+          currentStartIndex = -1;
+          break;
+        case STOP:
+          i = s.length();
+          break;
+        default:
+      }
+    }
+
+    // Build remaining query
+    StringBuilder remainingQuery = new StringBuilder();
+    int currentPos = 0;
+    for (int[] range : excludeRanges) {
+      if (currentPos < range[0]) {
+        remainingQuery.append(s, currentPos, range[0]);
+      }
+      currentPos = range[1];
+    }
+    if (currentPos < s.length()) {
+      remainingQuery.append(s, currentPos, s.length());
+    }
+
+    return new ParseResult(settings, remainingQuery.toString(), errors);
+  }
+
+  private void parseKeyValue(String kv, Map<String, String> settings, List<String> errors) {
+    int eqIdx = kv.indexOf('=');
+    if (eqIdx == -1) {
+      errors.add("Invalid key-value pair '" + kv + "': missing '='");
+      return;
+    }
+    String key = kv.substring(0, eqIdx).trim();
+    if (key.isEmpty()) {
+      errors.add("Invalid key-value pair '" + kv + "': empty key");
+      return;
+    }
+    String value = eqIdx < kv.length() - 1 ? kv.substring(eqIdx + 1).trim() : "";
+    value = value.replace("\\;", ";");
+    settings.put(key, value);
+  }
+}

--- a/src/main/java/com/aliyun/odps/jdbc/utils/SettingParser.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/SettingParser.java
@@ -50,6 +50,8 @@ public class SettingParser {
     List<String> errors = new ArrayList<>();
     List<int[]> excludeRanges = new ArrayList<>();
     State currentState = State.DEFAULT;
+    // use for ignore the case of 'set'
+    String lowerS = s.toLowerCase();
     int i = 0;
     int currentStartIndex = -1;
 
@@ -62,7 +64,7 @@ public class SettingParser {
           } else if (i <= s.length() - 2 && s.startsWith("/*", i)) {
             currentState = State.MULTI_LINE_COMMENT;
             i += 2;
-          } else if (i <= s.length() - 3 && (s.startsWith("set", i) || s.startsWith("SET", i))) {
+          } else if (i <= s.length() - 3 && lowerS.startsWith("set", i)) {
             if (i + 3 < s.length() && Character.isWhitespace(s.charAt(i + 3))) {
               currentState = State.IN_SET;
               currentStartIndex = i;
@@ -113,6 +115,7 @@ public class SettingParser {
           int keyValueStart = i;
           boolean foundSemicolon = false;
           while (i < s.length()) {
+            // Allows escape of semicolons to place semicolons in settings
             if (s.charAt(i) == ';' && s.charAt(i - 1) != '\\') {
               foundSemicolon = true;
               i++;

--- a/src/test/java/com/aliyun/odps/jdbc/utils/SettingParserTest.java
+++ b/src/test/java/com/aliyun/odps/jdbc/utils/SettingParserTest.java
@@ -11,7 +11,7 @@ public class SettingParserTest {
   public void testStandardScenario() {
     String sql = "/* pre comment */\n"
                  + "SET key1 = value1; -- inline comment\n"
-                 + "SET key2=value2;\n"
+                 + "SeT key2=value2;\n"
                  + "SELECT 1;";
 
     SettingParser parser = new SettingParser();

--- a/src/test/java/com/aliyun/odps/jdbc/utils/SettingParserTest.java
+++ b/src/test/java/com/aliyun/odps/jdbc/utils/SettingParserTest.java
@@ -1,0 +1,80 @@
+package com.aliyun.odps.jdbc.utils;
+
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.Map;
+
+public class SettingParserTest {
+  // 基础测试用例
+  @Test
+  public void testStandardScenario() {
+    String sql = "/* pre comment */\n"
+                 + "SET key1 = value1; -- inline comment\n"
+                 + "SET key2=value2;\n"
+                 + "SELECT 1;";
+
+    SettingParser parser = new SettingParser();
+    SettingParser.ParseResult result = parser.extractSetStatements(sql);
+
+    // 验证设置项
+    Map<String, String> settings = result.getSettings();
+    assertEquals(2, settings.size());
+    assertEquals("value1", settings.get("key1"));
+    assertEquals("value2", settings.get("key2"));
+
+    // 验证剩余SQL
+    String expectedRemaining = "/* pre comment */\n -- inline comment\n\nSELECT 1;";
+    assertEquals(expectedRemaining, result.getRemainingQuery());
+
+    // 验证错误信息
+    assertTrue(result.getErrors().isEmpty());
+  }
+
+  // 注释嵌套测试
+  @Test
+  public void testNestedComments() {
+    String sql = "/**//*! SET invalid1=1 */\n"
+                 + "-- SET invalid2=2\n"
+                 + "SET /*inner*/valid3=3; -- end\n"
+                 + "SELECT '--string'/*, \"SET\"*/;";
+
+    SettingParser.ParseResult result = new SettingParser().extractSetStatements(sql);
+
+    assertEquals(1, result.getSettings().size());
+    assertEquals("3", result.getSettings().get("/*inner*/valid3"));
+
+    String expected = "/**//*! SET invalid1=1 */\n-- SET invalid2=2\n -- end\nSELECT '--string'/*, \"SET\"*/;";
+    assertEquals(expected, result.getRemainingQuery());
+  }
+
+  // 错误场景测试
+  @Test
+  public void testErrorScenarios() {
+    SettingParser parser = new SettingParser();
+
+    // 缺少分号
+    String sql1 = "SET key=value";
+    SettingParser.ParseResult r1 = parser.extractSetStatements(sql1);
+    assertEquals(1, r1.getErrors().size());
+    assertTrue(r1.getErrors().get(0).contains("missing semicolon"));
+
+    // 无效键值对
+    String sql2 = "SET invalid;";
+    SettingParser.ParseResult r2 = parser.extractSetStatements(sql2);
+    assertEquals(1, r2.getErrors().size());
+    assertTrue(r2.getErrors().get(0).contains("missing '='"));
+  }
+
+  // 字符串保护测试
+  @Test
+  public void testStringProtection() {
+    String sql = "SET key = 'semi\\;colon';\n"
+                 + "SELECT '--fake_comment', \"/*fake*/\";";
+
+    SettingParser.ParseResult result = new SettingParser().extractSetStatements(sql);
+
+    assertEquals("'semi;colon'", result.getSettings().get("key"));
+    assertEquals("\nSELECT '--fake_comment', \"/*fake*/\";", result.getRemainingQuery());
+  }
+}


### PR DESCRIPTION
**Description:**
This pull request introduces the `SettingParser`, which enables a more accurate extraction of settings from SQL statements. By moving away from the previous regex-based approach, we mitigate the risk of inadvertently removing valid SQL components while stripping out comments. This enhancement ensures that we handle SQL parsing more reliably and effectively.
