### PR TITLE
[minor] Fix a few typos

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/OdpsConnection.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsConnection.java
@@ -315,7 +315,7 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
     } else {
       this.odpsNamespaceSchema = connRes.isOdpsNamespaceSchema();
     }
-    log.info("Supoort odps namespace schema: " + this.odpsNamespaceSchema);
+    log.info("Support odps namespace schema: " + this.odpsNamespaceSchema);
     if (this.odpsNamespaceSchema) {
       sqlTaskProperties.put("odps.namespace.schema", "true");
     }

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsPreparedStatement.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsPreparedStatement.java
@@ -81,7 +81,7 @@ public class OdpsPreparedStatement extends AbstractOdpsPreparedStatement {
 
   private static final String
       SQL_REGEX =
-      "(')|(--)|(/\\*(?:.|[\\n\\r])*?\\*/)|(\\b(select|update|and|or|delete|insert|trancate|char|substr|ascii|declare|exec|count|master|into|drop|execute)\\b)";
+      "(')|(--)|(/\\*(?:.|[\\n\\r])*?\\*/)|(\\b(select|update|and|or|delete|insert|truncate|char|substr|ascii|declare|exec|count|master|into|drop|execute)\\b)";
 
   private static final Pattern SQL_PATTERN = Pattern.compile(SQL_REGEX, Pattern.CASE_INSENSITIVE);
 


### PR DESCRIPTION
## What do these changes do?
This PR fixes two typos.

<!-- Please give a short brief about these changes. -->
One typo is during a logging call. This is very minor inconvenience. 

The other exists in SQL_PATTERN and is more important as it is used when protecting against sql injections in the function `isIllegal()`
https://github.com/aliyun/aliyun-odps-jdbc/blob/ccbd6c47a7fb4ce97faa91610670202d3b05b2e4/src/main/java/com/aliyun/odps/jdbc/OdpsPreparedStatement.java#L595-L600

## Related issue number
None
<!-- Are there any issues opened that will be resolved by merging this change? -->
