### PR TITLE
feat(jdbc): add autoPartitionFilter to auto-inject partition filter and limit for bare SELECT queries

### DIFF
--- a/src/main/java/com/aliyun/odps/jdbc/OdpsConnection.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsConnection.java
@@ -115,6 +115,10 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
 
   private boolean autoLimitFallback = false;
 
+  private boolean autoPartitionFilter = false;
+
+  private Long autoPartitionFilterLimit;
+
   private SQLExecutorBuilder executorBuilder;
 
   private SQLExecutor executor = null;
@@ -286,6 +290,8 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
     this.fallbackQuota = connRes.getFallbackQuota();
     this.disableFallback = connRes.isDisableFallback();
     this.autoLimitFallback = connRes.isAutoLimitFallback();
+    this.autoPartitionFilter = connRes.isAutoPartitionFilter();
+    this.autoPartitionFilterLimit = connRes.getAutoPartitionFilterLimit();
     this.enableCommandApi = connRes.isEnableCommandApi();
     this.httpsCheck = connRes.isHttpsCheck();
     this.skipSqlCheck = connRes.isSkipSqlRewrite();
@@ -943,6 +949,14 @@ public class OdpsConnection extends WrapperAdapter implements Connection {
 
   public boolean isAutoLimitFallback() {
     return autoLimitFallback;
+  }
+
+  public boolean isAutoPartitionFilter() {
+    return autoPartitionFilter;
+  }
+
+  public Long getAutoPartitionFilterLimit() {
+    return autoPartitionFilterLimit;
   }
 
   public void setEnableLimit(boolean enableLimit) {

--- a/src/main/java/com/aliyun/odps/jdbc/OdpsStatement.java
+++ b/src/main/java/com/aliyun/odps/jdbc/OdpsStatement.java
@@ -31,12 +31,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import com.aliyun.odps.Column;
 import com.aliyun.odps.Instance;
 import com.aliyun.odps.OdpsException;
+import com.aliyun.odps.Table;
 import com.aliyun.odps.data.Record;
 import com.aliyun.odps.jdbc.utils.InstanceDataIterator;
 import com.aliyun.odps.jdbc.utils.OdpsLogger;
@@ -805,6 +808,12 @@ public class OdpsStatement extends WrapperAdapter implements Statement {
       if (connHandle.isReadOnlyConnection()) {
         settings.put("odps.sql.read.only", "true");
       }
+      String rewritten = rewriteBareSelect(sql, isUpdate);
+      if (rewritten != null) {
+        connHandle.log.info("Auto-rewrote bare SELECT to: " + rewritten);
+        sql = rewritten;
+      }
+
       connHandle.log.info("Run SQL: " + sql + ", Begin time: " + begin);
       executor.run(sql, settings);
       logviewUrl = executor.getLogView();
@@ -858,6 +867,95 @@ public class OdpsStatement extends WrapperAdapter implements Statement {
       }
     } catch (OdpsException | IOException e) {
       throwSQLException(e, sql, executor.getInstance(), executor.getLogView());
+    }
+  }
+
+  private String rewriteBareSelect(String sql, boolean isUpdate) {
+    if (isUpdate || !connHandle.isAutoPartitionFilter()) {
+      return null;
+    }
+
+    String stripped = Utils.removeComments(sql);
+    stripped = stripped.trim();
+    if (stripped.endsWith(";")) {
+      stripped = stripped.substring(0, stripped.length() - 1).trim();
+    }
+
+    try {
+      if (!isQuery(stripped)) {
+        return null;
+      }
+    } catch (SQLException e) {
+      return null;
+    }
+
+    Pattern forbiddenPattern = Pattern.compile(
+        "(?i)\\b(WHERE|LIMIT|GROUP\\s+BY|ORDER\\s+BY|HAVING|UNION|JOIN|INTO)\\b");
+    if (forbiddenPattern.matcher(stripped).find()) {
+      return null;
+    }
+
+    Pattern fromPattern = Pattern.compile("(?i)\\bFROM\\s+([`\\w.]+)\\b");
+    Matcher matcher = fromPattern.matcher(stripped);
+    if (!matcher.find()) {
+      return null;
+    }
+
+    String tableName = matcher.group(1).replace("`", "");
+
+    // Avoid rewriting multi-table queries like "FROM table1, table2"
+    int afterTable = matcher.end();
+    if (afterTable < stripped.length() && stripped.charAt(afterTable) == ',') {
+      return null;
+    }
+
+    try {
+      String project = null;
+      String schema = null;
+      String table = tableName;
+
+      if (tableName.contains(".")) {
+        String[] parts = tableName.split("\\.");
+        if (parts.length == 2) {
+          if (connHandle.isOdpsNamespaceSchema()) {
+            project = connHandle.getOdps().getDefaultProject();
+            schema = parts[0];
+            table = parts[1];
+          } else {
+            project = parts[0];
+            table = parts[1];
+          }
+        } else if (parts.length == 3) {
+          project = parts[0];
+          schema = parts[1];
+          table = parts[2];
+        } else {
+          return null;
+        }
+      }
+
+      Table odpsTable;
+      if (project != null && schema != null) {
+        odpsTable = connHandle.getOdps().tables().get(project, schema, table);
+      } else if (project != null) {
+        odpsTable = connHandle.getOdps().tables().get(project, table);
+      } else {
+        odpsTable = connHandle.getOdps().tables().get(table);
+      }
+      odpsTable.reload();
+
+      List<Column> partitionColumns = odpsTable.getSchema().getPartitionColumns();
+      if (partitionColumns == null || partitionColumns.isEmpty()) {
+        return null;
+      }
+
+      String partitionCol = partitionColumns.get(0).getName();
+      long limit = connHandle.getAutoPartitionFilterLimit();
+
+      return stripped + " WHERE `" + partitionCol + "` IS NOT NULL LIMIT " + limit + ";";
+    } catch (Exception e) {
+      connHandle.log.warn("Failed to apply auto partition filter for table '" + tableName + "': " + e.getMessage());
+      return null;
     }
   }
 

--- a/src/main/java/com/aliyun/odps/jdbc/utils/ConnectionResource.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/ConnectionResource.java
@@ -81,6 +81,8 @@ public class ConnectionResource {
   private static final String USE_PROJECT_TIME_ZONE_URL_KEY = "useProjectTimeZone";
   private static final String ENABLE_LIMIT_URL_KEY = "enableLimit";
   private static final String AUTO_LIMIT_FALLBACK_URL_KEY = "autoLimitFallback";
+  private static final String AUTO_PARTITION_FILTER_URL_KEY = "autoPartitionFilter";
+  private static final String AUTO_PARTITION_FILTER_LIMIT_URL_KEY = "autoPartitionFilterLimit";
   private static final String SETTINGS_URL_KEY = "settings";
   private static final String ODPS_NAMESPACE_SCHEMA_URL_KEY = "odpsNamespaceSchema";
   private static final String SCHEMA_URL_KEY = "schema";
@@ -147,6 +149,8 @@ public class ConnectionResource {
   private static final String ENABLE_LIMIT_PROP_KEY = "enable_limit";
   // only applied in non-interactive mode
   private static final String AUTO_FALLBACK_PROP_KEY = "auto_limit_fallback";
+  private static final String AUTO_PARTITION_FILTER_PROP_KEY = "auto_partition_filter";
+  private static final String AUTO_PARTITION_FILTER_LIMIT_PROP_KEY = "auto_partition_filter_limit";
   private static final String SETTINGS_PROP_KEY = "settings";
   // This is to support DriverManager.getConnection(url, user, password) API,
   // which put the 'user' and 'password' to the 'info'.
@@ -201,6 +205,8 @@ public class ConnectionResource {
   private Boolean skipCheckIfEpv2 = null;
   private boolean enableLimit = false;
   private boolean autoLimitFallback = false;
+  private boolean autoPartitionFilter = false;
+  private Long autoPartitionFilterLimit;
   private boolean enableCommandApi = false;
   private boolean useInstanceTunnel = true;
   private boolean httpsCheck = false;
@@ -451,6 +457,14 @@ public class ConnectionResource {
 
     autoLimitFallback = Boolean.parseBoolean(tryGetFirstNonNullValueByAltMapAndAltKey(
         maps, "false", AUTO_FALLBACK_PROP_KEY, AUTO_LIMIT_FALLBACK_URL_KEY));
+
+    autoPartitionFilter = Boolean.parseBoolean(tryGetFirstNonNullValueByAltMapAndAltKey(
+        maps, "false", AUTO_PARTITION_FILTER_PROP_KEY, AUTO_PARTITION_FILTER_URL_KEY));
+
+    autoPartitionFilterLimit = Long.valueOf(
+        tryGetFirstNonNullValueByAltMapAndAltKey(maps, "100", AUTO_PARTITION_FILTER_LIMIT_PROP_KEY,
+                                                 AUTO_PARTITION_FILTER_LIMIT_URL_KEY)
+    );
 
     enableCommandApi =
         Boolean.parseBoolean(
@@ -771,6 +785,14 @@ public class ConnectionResource {
 
   public boolean isAutoLimitFallback() {
     return autoLimitFallback;
+  }
+
+  public boolean isAutoPartitionFilter() {
+    return autoPartitionFilter;
+  }
+
+  public Long getAutoPartitionFilterLimit() {
+    return autoPartitionFilterLimit;
   }
 
   public Map<String, String> getSettings() {

--- a/src/main/java/com/aliyun/odps/jdbc/utils/Utils.java
+++ b/src/main/java/com/aliyun/odps/jdbc/utils/Utils.java
@@ -176,7 +176,7 @@ public class Utils {
   private static final Pattern INLINE_COMMENT_PATTERN = Pattern.compile("(?ms)--.*?$");
   private static final Pattern MULTILINE_COMMENT_PATTERN = Pattern.compile("(?ms)/\\*(?!\\+).*?\\*/");
 
-  private static String removeComments(String sql) {
+  public static String removeComments(String sql) {
     sql = removePattern(sql, INLINE_COMMENT_PATTERN);
     sql = removePattern(sql, MULTILINE_COMMENT_PATTERN);
     return sql;


### PR DESCRIPTION
## What do these changes do?

**TLDR:**

When autoPartitionFilter is enabled via connection property, the driver detects bare SELECT queries (no WHERE/LIMIT/JOIN/etc.) against partitioned tables and rewrites them to inject 'WHERE <partition_col> IS NOT NULL LIMIT N' before submitting to MaxCompute. This prevents the ODPS-0130071 full-scan partition error.

New connection properties:
- autoPartitionFilter / auto_partition_filter (default false)
- autoPartitionFilterLimit / auto_partition_filter_limit (default 100)

### Problem

When executing bare SELECT * FROM table queries against partitioned MaxCompute tables without specifying partition predicates, MaxCompute returns the following error:

```
ODPS-0130071:[0,0] Semantic analysis exception - physical plan generation failed:
Table(project,schema,table) is full scan with all partitions, please specify partition predicates.
```

This is a common issue for users running ad-hoc queries through BI tools or SQL clients that generate simple SELECT * statements. The query fails entirely even when the user just wants a quick preview of the data.

### Proposed Solution

Add an opt-in connection property autoPartitionFilter that automatically detects "bare" SELECT queries (no WHERE, LIMIT, JOIN, GROUP BY, etc.), looks up the target table's partition columns, and rewrites the SQL to inject:

```
WHERE `<partition_col>` IS NOT NULL LIMIT <N>;
```

This satisfies MaxCompute's partition predicate requirement while keeping the result semantics identical for typical partition columns (which are non-NULL by design).

### New Connection Properties

Property (URL) | Property (Properties) | Type | Default | Description
-- | -- | -- | -- | --
autoPartitionFilter | auto_partition_filter | boolean | false | Enable automatic partition filter injection
autoPartitionFilterLimit | auto_partition_filter_limit | long | 100 | LIMIT value to append to rewritten queries

### Usage Example

Via JDBC URL:

```
String url = "jdbc:odps:http://service.odps.aliyun.com/api?project=my_project&autoPartitionFilter=true&autoPartitionFilterLimit=100";
```

Via Properties:

```
Properties props = new Properties();
props.setProperty("auto_partition_filter", "true");
props.setProperty("auto_partition_filter_limit", "100");
Connection conn = DriverManager.getConnection(url, props);
```

### How It Works
1. Detection: In `OdpsStatement.runSQL()`, before submitting to the executor, the driver checks if:
- `autoPartitionFilter` is enabled
- The query is a `SELECT` (not DML/DDL)
- The query has no WHERE, LIMIT, GROUP BY, ORDER BY, HAVING, UNION, JOIN, or INTO clauses
- The query references a single table (multi-table comma-joins are excluded)

2. Metadata lookup: The driver extracts the table name from the FROM clause, resolves it using the current odpsNamespaceSchema mode (2-tier project.table or 3-tier project.schema.table), and fetches the table metadata via the ODPS SDK.

3. Rewrite: If the table is partitioned, the driver appends:
```
WHERE `<first_partition_col>` IS NOT NULL LIMIT <autoPartitionFilterLimit>;
```
4. Graceful fallback: If table metadata lookup fails for any reason (network, permissions, table doesn't exist), the driver logs a warning and submits the original SQL unchanged — the query behavior never regresses.

### Backward Compatibility
Fully backward compatible: the feature is disabled by default.
No changes to existing behavior unless `autoPartitionFilter=true` is explicitly set.

## Related issue number
https://github.com/aliyun/aliyun-odps-jdbc/issues/172