### PR TITLE
Fix: Update Netty to 4.1.135.Final to resolve CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
           <dependency>
               <groupId>io.netty</groupId>
               <artifactId>netty-bom</artifactId>
-              <version>4.1.133.Final</version>
+              <version>4.1.135.Final</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>


### PR DESCRIPTION
这些改动的作用是什么？
此合并请求将 Netty 依赖项更新到了最新的安全版本 (4.1.135.Final)，以解决当前打包在包含所有依赖的 JAR 文件中的 Netty 所涉及的新增高危安全漏洞。
由于 Netty 是作为几个模块（如 arrow-memory-netty 和 odps-sdk-core）的传递依赖被引入的，因此继续通过根目录 pom.xml 中 <dependencyManagement> 节点的 netty-bom 来统一管理该版本。
这种做法能够整洁地在所有 Netty 制品中强制统一使用安全版本，同时完全遵循您现有的局部排除规则（例如 arrow-memory-netty 内部对 netty-common 的排除）。我已验证了依赖树，并在本地成功完成了项目的构建。

相关问题编号
无（针对 Netty 最新安全漏洞的主动性补丁）

What do these changes do?
This PR updates the Netty dependency to the latest secure version (4.1.135.Final) to resolve newly reported High-severity CVEs associated with Netty versions currently bundled in the Fat JAR.
Since Netty is brought in as a transitive dependency by several modules (like arrow-memory-netty and odps-sdk-core), the version continues to be managed centrally via the netty-bom within the <dependencyManagement> section of the root pom.xml.
This approach cleanly enforces the secure version across all Netty artifacts while perfectly respecting your existing local <exclusions> (such as the netty-common exclusion inside arrow-memory-netty). I have verified the dependency tree and built the project locally with success.

Related issue number
N/A (Proactive security patch for the latest Netty CVEs)