### PR TITLE
Fix: Update jackson-databind and jackson-core to 2.21.4 to resolve CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,12 +321,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.21.1</version>
+      <version>2.21.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.21.1</version>
+      <version>2.21.4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
这些改动的作用是什么？
此合并请求将 jackson-databind 和 jackson-core 依赖项更新到了最新可用版本 (2.21.4)，以解决当前打包版本 (2.21.1) 中涉及的多个高危安全漏洞。
请注意： 我们了解到 2.21.4 版本仍有一个未决的 CVE，但此次更新已经大幅降低了安全风险。一旦 2.21.5 正式发布，我们将跟进彻底解决。我已验证了依赖树，并在本地成功完成了项目的构建。

相关问题编号
无（针对 Jackson 多个安全漏洞的主动性补丁）

What do these changes do?
This PR updates the jackson-databind and jackson-core dependencies to the latest available version (2.21.4) to address multiple High-severity CVEs present in the currently bundled version (2.21.1).
Please note: We are aware that version 2.21.4 still has one pending CVE, but this update significantly reduces the security surface. We plan to follow up and update to 2.21.5 once it is officially released. I have verified the dependency tree and built the project locally with success.

Related issue number
N/A (Proactive security patch for Jackson CVEs)