### PR TITLE
Fix: Update jackson-databind and jackson-core to 2.21.5 to fully resolve CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,12 +321,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.21.4</version>
+      <version>2.21.5</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.21.4</version>
+      <version>2.21.5</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hi again @dingxin-tech!

As mentioned in the previous PR, version 2.21.5 has just been officially released. This update completely clears the remaining CVEs (which were still present in 2.21.4). This PR bumps the version to fully resolve the security issue.

再次你好 @dingxin-tech！

正如在之前的 PR 中提到的，2.21.5 版本刚刚正式发布。此更新完全清除了剩余的 CVE（在 2.21.4 中仍然存在）。此 PR 提升了版本以彻底解决安全问题。感谢你的时间！
