### PR TITLE
Fix: Update Netty, Jackson, and LZ4 to resolve multiple high-severity CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
           <dependency>
               <groupId>io.netty</groupId>
               <artifactId>netty-bom</artifactId>
-              <version>4.1.135.Final</version>
+              <version>4.1.136.Final</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
           <dependency>
               <groupId>io.netty</groupId>
               <artifactId>netty-bom</artifactId>
-              <version>4.1.136.Final</version>
+              <version>4.1.137.Final</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>
@@ -327,6 +327,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.21.5</version>
+    </dependency>
+    <dependency>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.11.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Hi @lyman and @dingxin-tech,

Since the PR was still pending, I took the opportunity to update the branch with additional security patches requested by our security team.

What do these changes do?

This PR now updates netty-bom, jackson-databind, jackson-core, and lz4-java to their latest secure versions to resolve multiple High and Medium-severity CVEs flagged by SCA tools.

Specifically, this update fixes the following vulnerabilities:

Netty (Bumped to 4.1.137.Final)

Jackson (Bumped to 2.21.5)
Resolves: CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54516, CVE-2026-54517, CVE-2026-54518, GHSA-r7wm-3cxj-wff9.

LZ4 (Bumped to relocated at.yawk.lz4 1.11.2)
Resolves: CVE-2026-59949.

As noted in the related issue, because these dependencies are shaded into the published odps-jdbc JAR, downstream consumers cannot override the versions via their own BOM. Therefore, this upstream bump is necessary to keep consumers secure and pass security gates.

Thanks for your time reviewing this!

你好 @lyman 和 @dingxin-tech，

由于之前的 PR 还在待审核状态，我借此机会更新了分支，加入了我们安全团队要求的其他安全补丁。

这些改动的作用是什么？

此合并请求现在将 netty-bom、jackson-databind、jackson-core 和 lz4-java 更新到了最新的安全版本，以解决 SCA 工具标记的多个高危和中危安全漏洞 (CVE)。

具体来说，此更新修复了以下漏洞：

Netty (升级至 4.1.137.Final)

Jackson (升级至 2.21.5)
修复了：CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54516, CVE-2026-54517, CVE-2026-54518, GHSA-r7wm-3cxj-wff9。

LZ4 (升级至重新定位的 at.yawk.lz4 1.11.2)
修复了：CVE-2026-59949。

正如相关 Issue 中指出的那样，由于这些依赖项被 shaded（遮蔽）到了发布的 odps-jdbc JAR 中，下游使用者无法通过他们自己的 BOM 来覆盖版本。因此，必须在本项目中直接升级版本，以确保使用者的安全并通过安全扫描。

感谢您抽出时间审查此 PR！

Related issue number / 相关问题编号
Fixes #178